### PR TITLE
Allow specifying compression encoding order

### DIFF
--- a/tonic/Cargo.toml
+++ b/tonic/Cargo.toml
@@ -57,6 +57,8 @@ tracing = "0.1"
 http-body = "0.4.4"
 percent-encoding = "2.1"
 pin-project = "1.0.11"
+strum = "0.26"
+strum_macros = "0.26"
 tower-layer = "0.3"
 tower-service = "0.3"
 

--- a/tonic/src/server/grpc.rs
+++ b/tonic/src/server/grpc.rs
@@ -187,14 +187,8 @@ where
     ) -> Self {
         let mut this = self;
 
-        for &encoding in CompressionEncoding::encodings() {
-            if accept_encodings.is_enabled(encoding) {
-                this = this.accept_compressed(encoding);
-            }
-            if send_encodings.is_enabled(encoding) {
-                this = this.send_compressed(encoding);
-            }
-        }
+        this.accept_compression_encodings = accept_encodings;
+        this.send_compression_encodings = send_encodings;
 
         this
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/hyperium/tonic/blob/master/CONTRIBUTING.md
-->

## Motivation
Although Zstd is significantly more performant (> 5x in our testing), the default chosen encoding remains Gzip when both are enabled. This blocks us from being able to gradually roll out zstd support for existing downstream clients before disabling Gzip entirely.


## Solution
This PR introduces a feature that allows for specifying the order of compression encodings. The key changes include:
	-	Updated EnabledCompressionEncodings to support ordering/prioritizing multiple compression encodings such as Gzip and Zstd.
	-	Modified the enable function to reorder encodings based on the priority, ensuring the most recently enabled encoding has the lowest priority- i.e "first in highest priority"
	-	Added new tests to validate the correct priority ordering of compression encodings settings.
	-  Make sure GRPC correctly copies this order for each connection as well.
	
The behavior is now "given a list of supported encodings, I will pick the highest priority one that I support"